### PR TITLE
Add go.mod file

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/bign8/ternary
+
+go 1.11


### PR DESCRIPTION
Updating package to include a go.mod file to ensure go module users can consume `github.com/bign8/ternary`.